### PR TITLE
update unmute behaviour to be more reliable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,16 +58,14 @@ async function exportZip(game: File, audio: FileList)
     {
         const path = audio[i].name;
 
-        lines.push(`<audio src="${path}" autoplay loop></audio>`);
+        lines.push(`<audio id="${path}" src="${path}" autoplay loop></audio>`);
         folder.file(path, await fileToBlob(audio[i]));
     }
 
     const clickToPlay = `
 <script>
 function unmute() {
-    Array.prototype.slice.call(document.getElementsByTagName("audio")).forEach(function(element){
-        element.play();
-    });
+    ${Array.from(audio).map(file => `document.getElementById("${file.name}").play();`).join('\n')}
     document.removeEventListener('pointerup', unmute);
     document.removeEventListener('keydown', unmute);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,6 +68,8 @@ function unmute() {
     Array.prototype.slice.call(document.getElementsByTagName("audio")).forEach(function(element){
         element.play();
     });
+    document.removeEventListener('pointerup', unmute);
+    document.removeEventListener('keydown', unmute);
 }
 document.addEventListener('pointerup', unmute);
 document.addEventListener('keydown', unmute);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,9 +62,20 @@ async function exportZip(game: File, audio: FileList)
         folder.file(path, await fileToBlob(audio[i]));
     }
 
-    const clickToPlay = `<script>document.addEventListener('mousedown', function(){ Array.prototype.slice.call(document.getElementsByTagName("audio")).forEach(function(element){ element.play(); }); });</script>`;
+    const clickToPlay = `
+<script>
+function unmute() {
+    Array.prototype.slice.call(document.getElementsByTagName("audio")).forEach(function(element){
+        element.play();
+    });
+}
+document.addEventListener('mousedown', unmute);
+</script>`;
 
-    const insert = `\n${lines.join("\n")}\n${clickToPlay}</body>`;
+    const insert = `
+${lines.join("\n")}
+${clickToPlay}
+</body>`;
 
     let html = await fileToString(game);
     html = html.replace("</body>", insert);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,7 +69,8 @@ function unmute() {
         element.play();
     });
 }
-document.addEventListener('mousedown', unmute);
+document.addEventListener('pointerup', unmute);
+document.addEventListener('keydown', unmute);
 </script>`;
 
     const insert = `


### PR DESCRIPTION
hey candle! did some more detailed testing around the audio autoplay restrictions while updating old games and found a couple things that would make this more reliable for different use cases

- unmute on `keydown` or `pointerup` instead of `mousedown`
  - `mousedown` doesn't meet the interaction requirements for mobile; `pointerup` works on both desktop and mobile
  - if the game already has focus on start some folks will just interact via keyboard without ever clicking
- remove listeners after unmute
- only unmute audio added via the tool
  - although it's designed for bitsy, it's possible to use this for pretty much any html file, including ones which already have audio tags that may not be intended for autoplay